### PR TITLE
Add Express backend with env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,19 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
 # trucking-interconecta
+
+## Running the backend
+
+The repository contains an Express based API in the `backend` directory. To run it locally:
+
+1. Install dependencies
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Start the server
+   ```bash
+   npm start
+   ```
+
+Create a `.env` file based on `.env.example` with your PostgreSQL and JWT settings. The server listens on the port defined by `PORT`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,16 @@
+# PostgreSQL configuration
+PG_HOST=localhost
+PG_PORT=5432
+PG_USER=postgres
+PG_PASSWORD=secret
+PG_DATABASE=trucking
+
+# JWT configuration
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRES_IN=1h
+
+# Session secret used by express-session
+SESSION_SECRET=change_this
+
+# Server port
+PORT=4000

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,90 @@
+require('dotenv').config();
+const express = require('express');
+const cors = require('cors');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const multer = require('multer');
+const session = require('express-session');
+const { Pool } = require('pg');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use(session({
+  secret: process.env.SESSION_SECRET || 'secret',
+  resave: false,
+  saveUninitialized: false
+}));
+
+const upload = multer({ dest: 'uploads/' });
+
+const tenantPools = {};
+function getTenantPool(tenant) {
+  if (!tenantPools[tenant]) {
+    tenantPools[tenant] = new Pool({
+      host: process.env.PG_HOST,
+      port: process.env.PG_PORT,
+      user: process.env.PG_USER,
+      password: process.env.PG_PASSWORD,
+      database: `${process.env.PG_DATABASE}_${tenant}`
+    });
+  }
+  return tenantPools[tenant];
+}
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.sendStatus(401);
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.sendStatus(403);
+    req.user = user;
+    next();
+  });
+}
+
+app.post('/login', async (req, res) => {
+  const { username, password, tenant } = req.body;
+  try {
+    const pool = getTenantPool(tenant);
+    const result = await pool.query('SELECT id, password_hash FROM users WHERE username = $1', [username]);
+    if (result.rowCount === 0) return res.status(401).json({ error: 'Invalid credentials' });
+    const user = result.rows[0];
+    const match = await bcrypt.compare(password, user.password_hash);
+    if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+    const payload = { userId: user.id, tenant };
+    const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: process.env.JWT_EXPIRES_IN || '1h' });
+    req.session.tenant = tenant;
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+app.get('/profile', authenticateToken, async (req, res) => {
+  const { userId, tenant } = req.user;
+  try {
+    const pool = getTenantPool(tenant);
+    const result = await pool.query('SELECT id, username FROM users WHERE id = $1', [userId]);
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+app.post('/upload', authenticateToken, upload.single('file'), (req, res) => {
+  res.json({ file: req.file });
+});
+
+function startServer() {
+  const port = process.env.PORT || 4000;
+  app.listen(port, () => console.log(`Server running on port ${port}`));
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { app, startServer, authenticateToken };

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "trucking-interconecta-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.3",
+    "cors": "^2.8.5",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.1",
+    "multer": "^1.4.5-lts.1",
+    "dotenv": "^16.3.1",
+    "express-session": "^1.17.3"
+  }
+}


### PR DESCRIPTION
## Summary
- set up backend directory with Express server
- document environment variables
- add instructions to run the backend

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f97af48b8832b8abac59479f70673